### PR TITLE
Adding a minimal example for experimentation

### DIFF
--- a/examples/minimal/dadaStatusLED.h
+++ b/examples/minimal/dadaStatusLED.h
@@ -1,0 +1,88 @@
+/*
+   Copyright (c) 2017, DADAMACHINES
+   Author: Sven Braun
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without modification,
+   are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+        and/or other materials provided with the distribution.
+
+    3. Neither the name of DADAMACHINES nor the names of its contributors may be used
+       to endorse or promote products derived from this software without
+       specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+#ifndef _DARALED13_H
+#define _DARALED13_H
+
+#define loopTime  200     // speed depend on CPU Frequency
+
+class dadaStatusLED {
+  public:
+    int         _ledPin;
+    long        _on_time;
+    long        _off_time;
+    int         _times;
+    bool        _state;
+    long        _countDown;
+
+    dadaStatusLED(int pin) {
+      _ledPin = pin;
+      _times = 0;
+      pinMode(_ledPin, OUTPUT);   // pin leds to output
+    };
+
+    void blink( long on_time, long off_time, int count = -1) {
+      if (_times > 0) { // accept only requests wen finished
+        return;
+      }
+      _on_time    =  on_time * loopTime;
+      _off_time   =  off_time * loopTime;
+      _times      =  count;
+    };
+
+    void tick() {       // call this in MainLoop
+      if (_times == 0) {
+        return;
+      }
+
+      _countDown--;
+      if (_state) {
+        if (_countDown < 0) {
+          _state = ! _state;
+          _countDown = _off_time;
+          digitalWrite(_ledPin, LOW);
+          if (_times > 0 ) {
+            _times--;
+          }
+        }
+      } else {
+        if (_countDown < 0) {
+          _state = ! _state;
+          _countDown = _on_time;
+          digitalWrite(_ledPin, HIGH);
+        }
+      }
+    };
+
+};
+
+#endif

--- a/examples/minimal/minimal.ino
+++ b/examples/minimal/minimal.ino
@@ -1,0 +1,80 @@
+/* 
+ This is a minimal sketch meant for your own experiments. 
+ It defaults to accept midi on all channels from note C-2 (midi note 0) to B-1 (midi-note 11).
+*/
+
+#include <MIDI.h>
+#include <MIDIUSB.h>
+#include <SPI.h>
+
+// constants
+const int OUTPUT_PINS_COUNT = 12;                       //= sizeof(OUTPUT_PINS) / sizeof(OUTPUT_PINS[0]);
+const int LEARN_MODE_PIN = 38;                          // pin for the learn mode switch
+const int SHIFT_REGISTER_ENABLE = 27;                   // Output enable for shiftregister ic
+const int ACTIVITY_LED = 13;                            // activity led is still on D13 which is connected to PA17 > which means Pin 9 on MKRZero
+
+#include "solenoidSPI.h"
+SOLSPI solenoids(&SPI, 30);                             // PB22 Pin in new layout is Pin14 on MKRZero
+
+#include "dadaStatusLED.h"
+dadaStatusLED statusLED(ACTIVITY_LED);                  // led controller
+
+MIDI_CREATE_INSTANCE(HardwareSerial, Serial1, midi2);   // DIN Midi Stuff
+
+void setup() {
+  Serial1.begin(31250);                                 // set up MIDI baudrate
+  pinMode(SHIFT_REGISTER_ENABLE, OUTPUT);               // enable Shiftregister
+  digitalWrite(SHIFT_REGISTER_ENABLE, LOW);
+  pinMode(ACTIVITY_LED, OUTPUT);                        // pin leds to output
+  pinMode(LEARN_MODE_PIN, INPUT_PULLUP);
+  solenoids.begin();                                    // start shiftregister
+
+  midi2.setHandleNoteOn(handleNoteOn);                  // add Handler for Din MIDI
+  midi2.setHandleNoteOff(handleNoteOff);
+  midi2.begin(MIDI_CHANNEL_OMNI);
+  
+  statusLED.blink(20, 30, 32);
+}
+
+void loop() {
+  midi2.read();
+  statusLED.tick();
+
+  midiEventPacket_t rx;
+  do {
+    rx = MidiUSB.read();
+    if (rx.header != 0) {
+      switch (rx.byte1 & 0xF0) {
+        case 0x90:  // note on
+          if (rx.byte3 != 0)
+            handleNoteOn(1 + (rx.byte1 & 0xF), rx.byte2, rx.byte3);
+          else
+            handleNoteOff(1 + (rx.byte1 & 0xF), rx.byte2, rx.byte3);
+          break;
+        case 0x80: // note off
+          handleNoteOff(1 + (rx.byte1 & 0xF), rx.byte2, rx.byte3);
+          break;
+      }
+    }
+  } while (rx.header != 0);
+}
+
+void handleNoteOn(byte channel, byte note, byte velocity) {
+  statusLED.blink(1, 2, 1);
+  
+  for (int i = 0 ; i < 12 ; i++) {
+    if (note == i) {
+      solenoids.setOutput(i);
+    }
+  }
+}
+
+void handleNoteOff(byte channel, byte note, byte velocity) {
+  statusLED.blink(1, 2, 1);
+  
+  for (int i = 0 ; i < 12 ; i++) {
+    if (note == i) {
+      solenoids.clearOutput(i);
+    }
+  }
+}

--- a/examples/minimal/solenoidSPI.cpp
+++ b/examples/minimal/solenoidSPI.cpp
@@ -1,0 +1,112 @@
+/*
+   Copyright (c) 2016, DADAMACHINES
+   Author: Tobias Münzer
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without modification,
+   are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+        and/or other materials provided with the distribution.
+
+    3. Neither the name of DADAMACHINES nor the names of its contributors may be used
+       to endorse or promote products derived from this software without
+       specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "solenoidSPI.h"
+
+/*! The constructor takes two parameters.  The first is an SPI class
+    pointer.  This is the address of an SPI object (either the default
+    SPI object on the Arduino, or an object made using the DSPIx classes
+    on the chipKIT).  The second parameter is the chip select pin number
+    to use when communicating with the shift registers.
+
+    Example:
+
+
+        SOLSPI mySolenoids(&SPI, A1);
+
+*/
+#ifdef __PIC32MX__
+SOLSPI:: SOLSPI(DSPI *spi, uint8_t cs) {
+#else
+SOLSPI:: SOLSPI(SPIClass *spi, uint8_t cs) {
+#endif
+  _spi = spi;
+  _cs = cs;
+}
+
+#ifdef __PIC32MX__
+SOLSPI::SOLSPI(DSPI &spi, uint8_t cs) {
+#else
+SOLSPI::SOLSPI(SPIClass &spi, uint8_t cs) {
+#endif
+  _spi = &spi;
+  _cs = cs;
+}
+
+void SOLSPI::begin() {
+  outputState = 0;
+  _spi->begin();
+  pinMode(_cs, OUTPUT);
+  digitalWrite(_cs, LOW);
+  sendState();        //switch off all outputs
+}
+
+void SOLSPI::sendState()  {
+  digitalWrite(_cs, LOW);
+  _spi->transfer(outputState & 0xFF);
+  _spi->transfer(outputState >> 8);
+  digitalWrite(_cs, HIGH);
+}
+
+void SOLSPI::setOutput(uint8_t num) {
+  outputState |= (1 << translatePinNumber(num));
+  sendState();
+}
+
+void SOLSPI::clearOutput(uint8_t num) {
+  outputState &= ~(1 << translatePinNumber(num));
+  sendState();
+}
+
+void SOLSPI::singlePin(uint8_t num, bool on_or_off) {
+  uint16_t backup_outputState = outputState;
+  for (int i = 0 ; i < 12 ; i++) {
+    if (num == i && on_or_off) {
+      backup_outputState |= (1 << translatePinNumber(i));
+    } else {
+      backup_outputState &= ~(1 << translatePinNumber(i));
+    }
+  }
+  if (backup_outputState != outputState)  {
+    outputState=backup_outputState;
+    sendState();
+  }
+}
+
+uint8_t  SOLSPI::translatePinNumber(uint8_t n)  {
+  const uint8_t nums[12] = {15, 13, 12, 11, 7, 3, 14, 10, 9, 6, 5, 4};
+  if (n > 11)
+    return 8;
+  else
+    return nums[n];
+}
+
+

--- a/examples/minimal/solenoidSPI.h
+++ b/examples/minimal/solenoidSPI.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016, DADAMACHINES
+ * Author: Tobias Münzer
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, 
+ * are permitted provided that the following conditions are met:
+ * 
+ *  1. Redistributions of source code must retain the above copyright notice, 
+ *     this list of conditions and the following disclaimer.
+ * 
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ * 
+ *  3. Neither the name of DADAMACHINES nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef _SOLSPI_H
+#define _SOLSPI_H
+
+#if (ARDUINO >= 100) 
+# include <Arduino.h>
+#else
+# include <WProgram.h>
+#endif
+
+#ifdef __PIC32MX__
+#include <DSPI.h>
+#else
+#include <SPI.h>
+#endif
+
+class SOLSPI {
+    private:
+#ifdef __PIC32MX__
+        DSPI *_spi; /*! This points to a valid SPI object created from the chipKIT DSPI library. */
+#else
+        SPIClass *_spi; /*! This points to a valid SPI object created from the Arduino SPI library. */
+#endif
+        
+    uint8_t _cs;    /*! Chip select pin */
+    uint16_t outputState;
+    uint8_t translatePinNumber(uint8_t pin);
+    void sendState(void);
+    
+    public:
+#ifdef __PIC32MX__
+         SOLSPI(DSPI *spi, uint8_t cs);
+         SOLSPI(DSPI &spi, uint8_t cs);
+#else
+         SOLSPI(SPIClass *spi, uint8_t cs);
+         SOLSPI(SPIClass &spi, uint8_t cs);
+#endif
+        void begin();
+       
+        void setOutput(uint8_t addr); 
+        void clearOutput(uint8_t addr);
+        void singlePin(uint8_t num, bool on_or_off); // set a single pin an clear all other
+
+};
+#endif
+
+


### PR DESCRIPTION
The blink example is too barebone and the official firmware is too "big" as a starting point for experiments. A boilerplate with the most minimal functionality would enable us and other users to start experiments more quick. The sketch is only 80 lines of code and leaves out things like midi learn, velocity,  :)

This example/boilerplate will be in the future part of the arduino board package and thus visible in Arduino's example menu, when we update the git submodule in https://github.com/dadamachines/automat. I suggest we do this when we're done with v1.1.4.